### PR TITLE
Add patch workflow for advertisement key

### DIFF
--- a/apps/openhaystack-alternative/Makefile
+++ b/apps/openhaystack-alternative/Makefile
@@ -17,14 +17,17 @@ SHELL:=/bin/bash
 # BOARD_SIMPLE is the default board with no external crystal to maximize compatibility
 # BOARD_E104BT5032A is for E104-BT5032A board https://www.aliexpress.com/item/4000538644215.html
 # BOARD_ALIEXPRESS is for this "AliExpress beacon" https://www.aliexpress.com/item/32826502025.html
+# ADV_KEY_BASE64 the advertisment key(base64) from OpenHaystack app
+
+ADV_KEY_BASE64 ?=
+BOARD ?= BOARD_SIMPLE
+NEW_ADV_KEY_HEX := $(if $(ADV_KEY_BASE64),$(shell base64 -D <<< $(ADV_KEY_BASE64) | xxd -p),)
 
 # Compile for nrf52 by default, use "NRF_MODEL=nrf51 make" to compile for nrf51 platform
 ifeq ($(NRF_MODEL), nrf51)
 SOFTDEVICE_MODEL = s130
-BOARD ?= BOARD_SIMPLE
 else
 SOFTDEVICE_MODEL = s132
-BOARD ?= BOARD_SIMPLE
 NRF_MODEL = nrf52
 endif
 
@@ -48,13 +51,20 @@ else
 endif
 
 
-# I had some troubles to flashing the E104-BT5032A module, still not sure why, but I created this script that at least works better 
-# to me than "make flash". It works by trying to recover the device on a loop which it will erase all the flash contents and then 
+# I had some troubles to flashing the E104-BT5032A module, still not sure why, but I created this script that at least works better
+# to me than "make flash". It works by trying to recover the device on a loop which it will erase all the flash contents and then
 # it will programming it. You may need to unplug and plug VCC while executing this loop
 e104install:
 	mergehex -m ../../nrf5x-base/sdk/nrf51_sdk_11.0.0/components/softdevice/s132/hex/s132_nrf52_2.0.0_softdevice.hex _build/*.hex -o _build/full_firmware.bin
 	nrfjprog -f nrf52 --recover; while [ "$$?" -ne "0" ]; do echo "****** IMPORTANT: If you see this message for too long, please try to disconnect and connect VCC ******" && nrfjprog -f nrf52 --recover; done
 	nrfjprog -f nrf52 --program _build/full_firmware.bin --reset
+
+patch:
+ifneq ($(NEW_ADV_KEY_HEX),)
+	xxd -p -c 1000000 < compiled/$(NRF_MODEL)_firmware.bin | \
+		sed 's/$(shell echo -n 'OFFLINEFINDINGPUBLICKEYHERE!' | xxd -p)/$(NEW_ADV_KEY_HEX)/' | \
+		xxd -r -p > compiled/$(NRF_MODEL)_firmware_patched.bin
+endif
 
 LIBRARY_PATHS += .
 #SOURCE_PATHS += .

--- a/apps/openhaystack-alternative/README.md
+++ b/apps/openhaystack-alternative/README.md
@@ -27,3 +27,12 @@ NRF_MODEL=nrf51 make build
 this command will create a full binary to be flashed on the `compiled` directory.
 
 A compiled binary for both platforms is included for convenience.
+
+In case you can't or don't want to build the firmware,
+you can just patch existing firmware with your advertisement key from OpenHaystack app:
+
+```
+NRF_MODEL=nrf51 BOARD=BOARD_ALIEXPRESS ADV_KEY_BASE64=YOUR_ADVERTISEMENT_KEY make patch
+```
+
+this command will create the new patched binary (`nrf51_firmware_patched.bin`) with provided key on the `compiled` directory.


### PR DESCRIPTION
This PR will allow you to patch/replace the default advertisement key `OFFLINEFINDINGPUBLICKEYHERE!` with your advertisement key **without** changing/building  the source code every time you want to add new device.