### PR TITLE
Use brew to install nRF command line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ git submodule update
 
 ### Install required dependencies
  - nRF command line tools
- https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
+ `brew tap homebrew/cask-drivers; brew install --cask nordic-nrf-command-line-tools`
 
  - binutils
  `brew install binutils`
 
  - gcc-arm-none-eabi
- `brew cask install gcc-arm-embedded`
+ `brew install --cask gcc-arm-embedded`
 
 ### Compile the firmware
 Follow instructions on the `apps` folder


### PR DESCRIPTION
Heya mate, made a small PR so that the nRF command line tools can be installed easily (and automatically). Commit description below:

> Tap the homebrew/cask-drivers channel so that the nRF command line tools can be installed via brew. Also update the brew syntax to use the newer specifier for casks (`brew cask` is deprecated now).

The only thing I'm unsure about is if one should untap the homebrew/cask-drivers channel after installing the nRF command line tools (because one isn't probably going to use it...). What do you say?