### PR TITLE
Adding extra board configuration for AliExpress beacons without an XTAL

### DIFF
--- a/apps/openhaystack-alternative/Makefile
+++ b/apps/openhaystack-alternative/Makefile
@@ -17,6 +17,7 @@ SHELL:=/bin/bash
 # BOARD_SIMPLE is the default board with no external crystal to maximize compatibility
 # BOARD_E104BT5032A is for E104-BT5032A board https://www.aliexpress.com/item/4000538644215.html
 # BOARD_ALIEXPRESS is for this "AliExpress beacon" https://www.aliexpress.com/item/32826502025.html
+# BOARD_ALIEXPRESS_NO_XTAL is for AliExpress beacons without an XTAL
 # ADV_KEY_BASE64 the advertisment key(base64) from OpenHaystack app
 
 ADV_KEY_BASE64 ?=

--- a/apps/openhaystack-alternative/aliexpress_board_no_xtal.h
+++ b/apps/openhaystack-alternative/aliexpress_board_no_xtal.h
@@ -1,0 +1,89 @@
+/* Copyright (c) 2016 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+#ifndef ALIEXPRESS_BOARD_NO_XTAL_H
+#define ALIEXPRESS_BOARD_NO_XTAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// LEDs definitions
+#define LEDS_NUMBER    1
+
+#define LED_1          29
+
+#define LEDS_ACTIVE_STATE 0
+
+#define LEDS_LIST { LED_1}
+
+#define BSP_LED_0      LED_1
+
+#define LEDS_INV_MASK  0
+
+#define BUTTONS_NUMBER 1
+
+#define BUTTON_START   28
+#define BUTTON_1       28
+#define BUTTON_STOP    28
+#define BUTTON_PULL    NRF_GPIO_PIN_PULLUP
+
+#define BUTTONS_ACTIVE_STATE 0
+
+#define BUTTONS_LIST { BUTTON_1 }
+
+#define BSP_BUTTON_0   BUTTON_1
+
+#define RX_PIN_NUMBER  11
+#define TX_PIN_NUMBER  12
+#define CTS_PIN_NUMBER UART_PIN_DISCONNECTED
+#define RTS_PIN_NUMBER UART_PIN_DISCONNECTED
+#define HWFC           false
+
+// Arduino board mappings
+#define ARDUINO_SCL_PIN             27    // SCL signal pin
+#define ARDUINO_SDA_PIN             26    // SDA signal pin
+#define ARDUINO_AREF_PIN            2     // Aref pin
+#define ARDUINO_13_PIN              25    // Digital pin 13
+#define ARDUINO_12_PIN              24    // Digital pin 12
+#define ARDUINO_11_PIN              23    // Digital pin 11
+#define ARDUINO_10_PIN              22    // Digital pin 10
+#define ARDUINO_9_PIN               20    // Digital pin 9
+#define ARDUINO_8_PIN               19    // Digital pin 8
+
+#define ARDUINO_7_PIN               18    // Digital pin 7
+#define ARDUINO_6_PIN               17    // Digital pin 6
+#define ARDUINO_5_PIN               16    // Digital pin 5
+#define ARDUINO_4_PIN               15    // Digital pin 4
+#define ARDUINO_3_PIN               14    // Digital pin 3
+#define ARDUINO_2_PIN               13    // Digital pin 2
+#define ARDUINO_1_PIN               12    // Digital pin 1
+#define ARDUINO_0_PIN               11    // Digital pin 0
+
+#define ARDUINO_A0_PIN              3     // Analog channel 0
+#define ARDUINO_A1_PIN              4     // Analog channel 1
+#define ARDUINO_A2_PIN              28    // Analog channel 2
+#define ARDUINO_A3_PIN              29    // Analog channel 3
+#define ARDUINO_A4_PIN              30    // Analog channel 4
+#define ARDUINO_A5_PIN              31    // Analog channel 5
+
+// Low frequency clock source to be used by the SoftDevice
+#define NRF_CLOCK_LFCLKSRC      {.source        = NRF_CLOCK_LF_SRC_RC,              \
+                                 .rc_ctiv       = 16,                               \
+                                 .rc_temp_ctiv  = 2,                                \
+                                 .xtal_accuracy = 1}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ARDUINO_PRIMO_H

--- a/apps/openhaystack-alternative/boards.h
+++ b/apps/openhaystack-alternative/boards.h
@@ -48,6 +48,8 @@
   #include "e104bt5032a_board.h"
 #elif defined(BOARD_ALIEXPRESS)
   #include "aliexpress_board.h"
+#elif defined(BOARD_ALIEXPRESS_NO_XTAL)
+  #include "aliexpress_board_no_xtal.h"
 #elif defined(BOARD_SIMPLE)
   #include "simple_board.h"
 #else


### PR DESCRIPTION
Expanding on https://github.com/acalatrava/openhaystack-firmware/pull/8, this PR introduces an extra `BOARD` configuration for AliExpress beacons without an XTAL, `BOARD_ALIEXPRESS_NO_XTAL`.

Usage:
```
NRF_MODEL=nrf51 BOARD=BOARD_ALIEXPRESS_NO_XTAL make build

NRF_MODEL=nrf51 BOARD=BOARD_ALIEXPRESS_NO_XTAL ADV_KEY_BASE64='PUBKEY_HERE' make patch
```